### PR TITLE
Allow webhealth to be pushed to GCR OPS-671

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,9 @@
 
 GIT_HASH := $(shell git rev-parse --short HEAD)
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
-IMAGE_NAME := "dronedeploy/webhealth"
+APP_NAME := "webhealth"
+IMAGE_NAME := "dronedeploy/$(APP_NAME)"
+GCR_IMAGE := "gcr.io/dronedeploy-code-delivery-0/$(APP_NAME)"
 
 package:
 	docker build --build-arg GIT_HASH=$(GIT_HASH) -t $(IMAGE_NAME):$(GIT_HASH) .
@@ -12,7 +14,11 @@ test:
 
 tag:
 	docker tag $(IMAGE_NAME):$(GIT_HASH) $(IMAGE_NAME):$(GIT_BRANCH)
+	docker tag $(IMAGE_NAME):$(GIT_HASH) $(GCR_IMAGE):$(GIT_BRANCH)
+	docker tag $(IMAGE_NAME):$(GIT_HASH) $(GCR_IMAGE):$(GIT_HASH)
 
 push: tag
 	time docker push $(IMAGE_NAME):$(GIT_HASH)
 	time docker push $(IMAGE_NAME):$(GIT_BRANCH)
+	docker push $(GCR_IMAGE):$(GIT_HASH)
+	docker push $(GCR_IMAGE):$(GIT_BRANCH)


### PR DESCRIPTION
Reupload of the webhealth pod and push this to GCR as well.
Fixes issue with log-ship not being able to pull the `webhealth` container.